### PR TITLE
Modern badminton-themed UI refresh

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,34 +1,10 @@
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { ArrowRight, Bot, CalendarClock, Shield, Trophy, ClipboardList } from 'lucide-react';
-import Link from 'next/link';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-
-const BadmintonIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    className="h-10 w-10 text-primary"
-    data-ai-hint="badminton shuttlecock"
-  >
-    <path d="m15.18 2-6.25 6.25" />
-    <path d="M12.53 3.47 5.28 10.72" />
-    <path d="M10.72 5.28 3.47 12.53" />
-    <path d="M9.75 6.25 2 14" />
-    <path d="M14 22 8.5 16.5" />
-    <path d="m20.5 17.5-5-5" />
-    <path d="m17.5 20.5-5-5" />
-    <path d="M14.5 21.5-9 7" />
-  </svg>
-);
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { ShuttlecockIcon, RacketIcon, CourtIcon, ScoreboardIcon } from '@/components/icons/badminton';
 
 export default function LandingPage() {
   return (
@@ -36,7 +12,7 @@ export default function LandingPage() {
       <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="container flex h-20 max-w-screen-2xl items-center justify-between">
           <div className="flex items-center gap-3">
-            <BadmintonIcon />
+            <ShuttlecockIcon className="h-10 w-10 text-primary" />
             <h1 className="text-2xl font-semibold tracking-tight">
               Court<span className="text-primary">Commander</span>
             </h1>
@@ -52,8 +28,10 @@ export default function LandingPage() {
       </header>
 
       <main className="flex-grow">
-        <section className="relative overflow-hidden py-24 md:py-32">
-          <div className="container mx-auto text-center">
+        <section className="relative overflow-hidden py-24 md:py-32 bg-gradient-to-b from-primary/5 via-background to-background">
+          <ShuttlecockIcon className="absolute left-8 top-8 h-32 w-32 text-primary/10 -rotate-12" />
+          <ShuttlecockIcon className="absolute right-8 bottom-8 h-40 w-40 text-primary/10 rotate-12" />
+          <div className="container mx-auto text-center relative z-10">
             <h1 className="text-4xl md:text-6xl font-bold tracking-tighter mb-4">
               The Ultimate Badminton
             </h1>
@@ -81,7 +59,7 @@ export default function LandingPage() {
               <Card className="text-center border-2 border-transparent bg-background hover:border-primary hover:shadow-lg transition-all duration-300">
                 <CardHeader>
                   <div className="mx-auto bg-primary/10 p-4 rounded-full w-fit mb-2">
-                    <Bot className="h-8 w-8 text-primary" />
+                    <RacketIcon className="h-8 w-8 text-primary" />
                   </div>
                   <CardTitle className="font-medium">AI-Powered Matchmaking</CardTitle>
                 </CardHeader>
@@ -92,7 +70,7 @@ export default function LandingPage() {
               <Card className="text-center border-2 border-transparent bg-background hover:border-primary hover:shadow-lg transition-all duration-300">
                 <CardHeader>
                   <div className="mx-auto bg-primary/10 p-4 rounded-full w-fit mb-2">
-                    <CalendarClock className="h-8 w-8 text-primary" />
+                    <CourtIcon className="h-8 w-8 text-primary" />
                   </div>
                   <CardTitle className="font-medium">Automated Queue & Courts</CardTitle>
                 </CardHeader>
@@ -103,7 +81,7 @@ export default function LandingPage() {
               <Card className="text-center border-2 border-transparent bg-background hover:border-primary hover:shadow-lg transition-all duration-300">
                 <CardHeader>
                   <div className="mx-auto bg-primary/10 p-4 rounded-full w-fit mb-2">
-                    <Trophy className="h-8 w-8 text-primary" />
+                    <ScoreboardIcon className="h-8 w-8 text-primary" />
                   </div>
                   <CardTitle className="font-medium">Live Session Dashboard</CardTitle>
                 </CardHeader>
@@ -119,7 +97,7 @@ export default function LandingPage() {
       <footer className="py-8 border-t bg-muted/50">
         <div className="container mx-auto text-center text-muted-foreground">
           <div className="flex justify-center items-center gap-2 mb-2">
-            <BadmintonIcon />
+            <ShuttlecockIcon className="h-6 w-6 text-primary" />
             <p className="font-semibold text-foreground">CourtCommander</p>
           </div>
           <p className="text-sm">&copy; {new Date().getFullYear()} - The smartest way to play.</p>
@@ -137,7 +115,7 @@ export default function LandingPage() {
                 <TooltipTrigger asChild>
                     <Button asChild variant="secondary" size="icon" className="rounded-full shadow-lg">
                         <Link href="/qm">
-                            <ClipboardList />
+                            <CourtIcon />
                             <span className="sr-only">Queue Master</span>
                         </Link>
                     </Button>
@@ -150,7 +128,7 @@ export default function LandingPage() {
                 <TooltipTrigger asChild>
                     <Button asChild variant="secondary" size="icon" className="rounded-full shadow-lg">
                         <Link href="/admin">
-                            <Shield />
+                            <RacketIcon />
                             <span className="sr-only">Admin Panel</span>
                         </Link>
                     </Button>

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -6,7 +6,8 @@ import { onSnapshot, doc, collection } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { getClientId } from '@/lib/clientId';
 import LiveView from "@/components/session/LiveView";
-import { Shield, UserPlus, ClipboardList, Loader2 } from "lucide-react";
+import { UserPlus, Loader2 } from "lucide-react";
+import { CourtIcon, RacketIcon } from '@/components/icons/badminton';
 import MatchSuggester from "@/components/ai/MatchSuggester";
 import PlayerWizard from "@/components/session/PlayerWizard";
 import { Button } from "@/components/ui/button";
@@ -133,7 +134,7 @@ function PlayPageContent() {
                 <TooltipTrigger asChild>
                     <Button asChild variant="secondary" size="icon" className="rounded-full shadow-lg">
                         <Link href="/qm">
-                            <ClipboardList />
+                            <CourtIcon />
                             <span className="sr-only">Queue Master</span>
                         </Link>
                     </Button>
@@ -146,7 +147,7 @@ function PlayPageContent() {
                 <TooltipTrigger asChild>
                     <Button asChild variant="secondary" size="icon" className="rounded-full shadow-lg">
                         <Link href="/admin">
-                            <Shield />
+                            <RacketIcon />
                             <span className="sr-only">Admin Panel</span>
                         </Link>
                     </Button>

--- a/src/app/qm/layout.tsx
+++ b/src/app/qm/layout.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogPortal, DialogOverlay } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Home, KeyRound, Loader2, LogOut, X, ClipboardList } from "lucide-react";
+import { Home, KeyRound, Loader2, LogOut, X } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useToast } from "@/hooks/use-toast";
 import * as DialogPrimitive from "@radix-ui/react-dialog";

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,9 +1,9 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Shield, ClipboardList } from 'lucide-react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { CourtIcon, RacketIcon } from '@/components/icons/badminton';
 
 export default function TermsPage() {
     const effectiveDate = new Date().toLocaleDateString('en-US', {
@@ -217,7 +217,7 @@ export default function TermsPage() {
                 <TooltipTrigger asChild>
                     <Button asChild variant="secondary" size="icon" className="rounded-full shadow-lg">
                         <Link href="/qm">
-                            <ClipboardList />
+                            <CourtIcon />
                             <span className="sr-only">Queue Master</span>
                         </Link>
                     </Button>
@@ -230,7 +230,7 @@ export default function TermsPage() {
                 <TooltipTrigger asChild>
                     <Button asChild variant="secondary" size="icon" className="rounded-full shadow-lg">
                         <Link href="/admin">
-                            <Shield />
+                            <RacketIcon />
                             <span className="sr-only">Admin Panel</span>
                         </Link>
                     </Button>

--- a/src/components/icons/badminton.tsx
+++ b/src/components/icons/badminton.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+
+export const ShuttlecockIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <path d="M15.18 2 8.93 8.25" />
+    <path d="M12.53 3.47 5.28 10.72" />
+    <path d="M10.72 5.28 3.47 12.53" />
+    <path d="M9.75 6.25 2 14" />
+    <path d="M14 22 8.5 16.5" />
+    <path d="m20.5 17.5-5-5" />
+    <path d="m17.5 20.5-5-5" />
+    <path d="M21.5 14.5 9 2" />
+  </svg>
+);
+
+export const RacketIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <ellipse cx="9" cy="9" rx="5" ry="7" />
+    <line x1="14" y1="14" x2="21" y2="21" />
+    <line x1="11" y1="12" x2="14" y2="15" />
+  </svg>
+);
+
+export const CourtIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <rect x="2" y="3" width="20" height="18" rx="2" />
+    <line x1="12" y1="3" x2="12" y2="21" />
+    <line x1="2" y1="9" x2="22" y2="9" />
+    <line x1="2" y1="15" x2="22" y2="15" />
+  </svg>
+);
+
+export const ScoreboardIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <rect x="2" y="3" width="20" height="18" rx="2" />
+    <line x1="12" y1="8" x2="12" y2="21" />
+    <rect x="6.5" y="12" width="3" height="4" fill="currentColor" stroke="none" />
+    <rect x="14.5" y="12" width="3" height="4" fill="currentColor" stroke="none" />
+  </svg>
+);

--- a/src/components/layout/AdminNav.tsx
+++ b/src/components/layout/AdminNav.tsx
@@ -3,7 +3,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Home, ClipboardList, Settings } from "lucide-react"
+import { ShuttlecockIcon, CourtIcon, ScoreboardIcon, RacketIcon } from '@/components/icons/badminton'
 
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
@@ -15,22 +15,22 @@ export default function AdminNav() {
     {
       href: "/",
       label: "Home Page",
-      icon: Home
+      icon: ShuttlecockIcon
     },
     {
       href: "/play",
       label: "Live Session",
-      icon: ClipboardList,
+      icon: ScoreboardIcon,
     },
     {
         href: "/qm",
         label: "Queue Master",
-        icon: ClipboardList
+        icon: CourtIcon
     },
     {
       href: "/admin",
       label: "Dashboard",
-      icon: Settings
+      icon: RacketIcon
     },
   ]
 

--- a/src/components/session/AdminPanel.tsx
+++ b/src/components/session/AdminPanel.tsx
@@ -3,7 +3,8 @@
 
 import type { Session, Participant, Court } from '@/types';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Users, Shield, Settings, BarChart } from 'lucide-react';
+import { Users, Settings, BarChart } from 'lucide-react';
+import { RacketIcon } from '@/components/icons/badminton';
 import { Skeleton } from '../ui/skeleton';
 
 interface AdminPanelProps {
@@ -20,7 +21,7 @@ export default function AdminPanel({ session, participants, courts, basePath }: 
       <Card>
         <CardHeader>
            <CardTitle className="flex items-center gap-2">
-                <Shield />
+                <RacketIcon className="h-6 w-6" />
                 <Skeleton className="h-8 w-48" />
             </CardTitle>
             <Skeleton className="h-4 w-72" />
@@ -44,7 +45,7 @@ export default function AdminPanel({ session, participants, courts, basePath }: 
         <Card>
             <CardHeader>
                 <CardTitle className="flex items-center gap-2">
-                    <Shield />
+                    <RacketIcon className="h-5 w-5" />
                     Admin Overview
                 </CardTitle>
                 <CardDescription>High-level statistics and controls for this session.</CardDescription>


### PR DESCRIPTION
## Summary
- Revamp landing page with shuttlecock hero graphics, gradient background, and badminton-specific feature icons
- Replace generic icons across player, terms, and admin navigation with reusable badminton icons
- Introduce `badminton.tsx` icon set and apply it in AdminPanel and navigation

## Testing
- `npm run lint` *(fails: Next.js ESLint asks interactive configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a8ac77db14832e8a4456b658842c8d