### PR TITLE
Add skill- and age-weighted queue matching

### DIFF
--- a/src/components/session/CourtCard.tsx
+++ b/src/components/session/CourtCard.tsx
@@ -12,18 +12,20 @@ import { Avatar, AvatarFallback } from '../ui/avatar';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
 import { cn } from '@/lib/utils';
 import { getClientId } from '@/lib/clientId';
+import { selectBalancedPlayers } from '@/lib/matchmaking';
 
 interface CourtCardProps {
   basePath: string;
   court: Court;
   match?: Match;
   players: Participant[];
+  participants: Participant[];
   canCoach: boolean;
   waitingQueue: QueueItem[];
   gameType: 'singles' | 'doubles';
 }
 
-export default function CourtCard({ basePath, court, match, players, canCoach, waitingQueue, gameType }: CourtCardProps) {
+export default function CourtCard({ basePath, court, match, players, participants, canCoach, waitingQueue, gameType }: CourtCardProps) {
   const [loading, setLoading] = useState(false);
   const { toast } = useToast();
   const clientId = getClientId();
@@ -31,7 +33,8 @@ export default function CourtCard({ basePath, court, match, players, canCoach, w
   const handleCoachAssign = async () => {
     setLoading(true);
     const playersNeeded = gameType === 'doubles' ? 4 : 2;
-    const playerIds = waitingQueue.slice(0, playersNeeded).map(p => p.userId);
+    const selected = selectBalancedPlayers(waitingQueue, participants, playersNeeded);
+    const playerIds = selected.map(p => p.userId);
 
     if (playerIds.length < playersNeeded) {
       toast({

--- a/src/components/session/CourtGrid.tsx
+++ b/src/components/session/CourtGrid.tsx
@@ -35,6 +35,7 @@ export default function CourtGrid({
             court={court}
             match={match}
             players={players}
+            participants={participants}
             canCoach={canCoach}
             waitingQueue={waitingQueue}
             gameType={gameType}

--- a/src/lib/matchmaking.ts
+++ b/src/lib/matchmaking.ts
@@ -1,0 +1,46 @@
+import type { Participant, QueueItem } from '@/types';
+
+/**
+ * Selects a balanced set of players for a match based on skill (80%) and age (20%).
+ * Players are chosen such that the range of the weighted score within the group is minimal,
+ * promoting matches with similar skill and age profiles.
+ */
+export function selectBalancedPlayers(
+  waitingQueue: QueueItem[],
+  participants: Participant[],
+  playersPerMatch: number
+): Participant[] {
+  // Build candidate list with full participant details
+  const candidates = waitingQueue
+    .map(q => participants.find(p => p.userId === q.userId || p.id === q.userId))
+    .filter(Boolean) as Participant[];
+
+  if (candidates.length < playersPerMatch) return [];
+
+  const maxLevel = Math.max(...candidates.map(p => p.level), 1);
+  const maxAge = Math.max(...candidates.map(p => p.age), 1);
+
+  const scored = candidates.map(p => {
+    const levelNorm = p.level / maxLevel;
+    const ageNorm = p.age / maxAge; // older => higher value
+    // Younger and higher skill gets higher score
+    const score = 0.8 * levelNorm + 0.2 * (1 - ageNorm);
+    return { ...p, score };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+
+  let bestGroup = scored.slice(0, playersPerMatch);
+  let minRange = bestGroup[0].score - bestGroup[bestGroup.length - 1].score;
+
+  for (let i = 1; i <= scored.length - playersPerMatch; i++) {
+    const group = scored.slice(i, i + playersPerMatch);
+    const range = group[0].score - group[group.length - 1].score;
+    if (range < minRange) {
+      minRange = range;
+      bestGroup = group;
+    }
+  }
+
+  return bestGroup;
+}


### PR DESCRIPTION
## Summary
- add matchmaking utility to select balanced players using 80% skill and 20% age weighting
- prioritize similar players when assigning matches from queue
- pass participant details to court cards to enable weighted selection

## Testing
- `npm run lint` *(fails: interactive ESLint setup prompt)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a8b7a0712c832e9774d0eaf6329649